### PR TITLE
Remove gemspec warnings

### DIFF
--- a/symmetric_file.gemspec
+++ b/symmetric_file.gemspec
@@ -6,7 +6,6 @@ Gem::Specification.new do |s|
   s.authors           = ["James Healy"]
   s.email             = ["james.healy@theconversation.edu.au"]
   s.homepage          = "http://github.com/yob/symmetric_file"
-  s.has_rdoc          = true
   s.rdoc_options      << "--title" << "SymmetricFile" << "--line-numbers"
   s.files             =  Dir.glob("{lib,bin}/**/*") + ["README.markdown","MIT-LICENSE","CHANGELOG"]
   s.executables       = ["symmetric-file"]

--- a/symmetric_file.gemspec
+++ b/symmetric_file.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = "symmetric_file"
-  s.version           = "0.1.0"
+  s.version           = "0.1.1"
   s.summary           = "Create and edit encrypted text files"
   s.description       = "Simple management of encrypted text files - particularly useful for use with ruby projects stored in git. Uses AES-CBC with HMAC authentication."
   s.authors           = ["James Healy"]

--- a/symmetric_file.gemspec
+++ b/symmetric_file.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("rake", "~> 10.0")
   s.add_development_dependency("rspec", "~>3.0")
-  s.add_development_dependency("pry")
+  s.add_development_dependency("pry", "~> 0.11")
 end
 

--- a/symmetric_file.gemspec
+++ b/symmetric_file.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.email             = ["james.healy@theconversation.edu.au"]
   s.homepage          = "http://github.com/yob/symmetric_file"
   s.rdoc_options      << "--title" << "SymmetricFile" << "--line-numbers"
-  s.files             =  Dir.glob("{lib,bin}/**/*") + ["README.markdown","MIT-LICENSE","CHANGELOG"]
+  s.files             =  Dir.glob("{lib,bin}/**/*") + ["README.md","MIT-LICENSE","CHANGELOG"]
   s.executables       = ["symmetric-file"]
   s.license           = "MIT"
 


### PR DESCRIPTION
Hello @yob! 👋 

First, thank you very much for this gem! Love the neat and simple way to keep encrypted files on a repo ❤️ 

So, this PR intent is to update this gem's `gemspec` to remove all warnings raised by the latest Rubygems version, such as `#has_rdoc=` deprecation. This PR also removes the following warnings when building this gem:

- `README.markdown` non-existent file being referenced as a lib file
- Lock `pry`'s version development dependency (open-ended version)
